### PR TITLE
style(UserPicker): 'exact match' search result header

### DIFF
--- a/src/ui/shared-components/UserPicker.jsx
+++ b/src/ui/shared-components/UserPicker.jsx
@@ -367,9 +367,9 @@ class UserPicker extends React.Component {
                                 </div>
                             }
                             <List theme="large" clickable>
+                                {this.foundContact && this.renderList('title_exactMatch', [this.foundContact])}
                                 {this.renderList('title_favoriteContacts', this.options.favorites)}
                                 {this.renderList('title_allContacts', this.options.normal)}
-                                {this.foundContact && this.renderList('title_exactMatch', [this.foundContact])}
                             </List>
                         </div>
                     </div>

--- a/src/ui/shared-components/UserPicker.jsx
+++ b/src/ui/shared-components/UserPicker.jsx
@@ -159,7 +159,7 @@ class UserPicker extends React.Component {
         if (c === null || this.selected.find(s => s.username === this.query)) {
             return;
         }
-        this.query = '';
+        // this.query = '';
         if (this.isExcluded(c)) {
             return;
         }
@@ -367,10 +367,9 @@ class UserPicker extends React.Component {
                                 </div>
                             }
                             <List theme="large" clickable>
+                                {this.renderList('title_favoriteContacts', this.options.favorites)}
+                                {this.renderList('title_allContacts', this.options.normal)}
                                 {this.foundContact && this.renderList('title_exactMatch', [this.foundContact])}
-                                {!this.foundContact
-                                    && this.renderList('title_favoriteContacts', this.options.favorites)}
-                                {!this.foundContact && this.renderList('title_allContacts', this.options.normal)}
                             </List>
                         </div>
                     </div>

--- a/src/ui/shared-components/UserPicker.jsx
+++ b/src/ui/shared-components/UserPicker.jsx
@@ -222,7 +222,14 @@ class UserPicker extends React.Component {
         if (!items.length) return null;
         return (
             <div key={subTitle} className="user-list">
-                {!!subTitle && <ListHeading key={subTitle} caption={`${t(subTitle)} (${items.length})`} />}
+                {!!subTitle &&
+                    <ListHeading key={subTitle}
+                        caption={this.foundContact
+                            ? t(subTitle)
+                            : `${t(subTitle)} (${items.length})`
+                        }
+                    />
+                }
                 {items.map(c => (
                     <span key={c.username} data-id={c.username}>
                         <ListItem
@@ -360,7 +367,7 @@ class UserPicker extends React.Component {
                                 </div>
                             }
                             <List theme="large" clickable>
-                                {this.foundContact && this.renderList(null, [this.foundContact])}
+                                {this.foundContact && this.renderList('title_exactMatch', [this.foundContact])}
                                 {!this.foundContact
                                     && this.renderList('title_favoriteContacts', this.options.favorites)}
                                 {!this.foundContact && this.renderList('title_allContacts', this.options.normal)}

--- a/src/ui/shared-components/UserPicker.jsx
+++ b/src/ui/shared-components/UserPicker.jsx
@@ -159,7 +159,7 @@ class UserPicker extends React.Component {
         if (c === null || this.selected.find(s => s.username === this.query)) {
             return;
         }
-        // this.query = '';
+        this.query = '';
         if (this.isExcluded(c)) {
             return;
         }


### PR DESCRIPTION
#### Relevant info and issue/PR links 
https://app.clubhouse.io/peerio/story/3187/desktop-add-a-header-for-contact-exact-match
 copy: https://github.com/PeerioTechnologies/peerio-icebear/pull/151

#### Testing instructions  
This PR adds the "Exact match" header to the user search result when you get an exact username/email match. Also, filtered Favourites and All Contacts now remain visible when an Exact Match is found, and Exact Match appears below them.

This addition makes it slightly strange to search for a user outside of your contacts when creating a new Room. @mmfoscarpeerio is creating a separate story to redesign the room user search flow to bring it more in line with this one.

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
