### PR TITLE
chore: dev and release changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "homepage": "https://github.com/PeerioTechnologies/peerio-desktop#readme",
   "devDependencies": {
-    "@peerio/desktop-release-builder": "6.9.4",
+    "@peerio/desktop-release-builder": "6.13.0",
     "@types/chai": "4.1.2",
     "@types/chai-as-promised": "7.1.0",
     "@types/lodash": "4.14.107",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "postinstall": "./scripts/postinstall.sh",
     "=== MAIN COMMANDS ===": "",
     "start": "PEERIO_STAGING_SOCKET_SERVER=\"wss://hocuspocus.peerio.com\" npm run start-dev",
+    "start-medcryptor": "PEERIO_WHITELABEL=medcryptor npm start",
     "start-debug": "REMOTE_DEBUG_PORT=9222 npm run start",
     "start-latest": "git pull && npm install && npm run start",
     "start-dev": "(export NODE_ENV=development; npm run compile && run-p -l watch:* electron:run)",

--- a/src/config.js
+++ b/src/config.js
@@ -62,9 +62,15 @@ if (isDevEnv) {
 }
 
 // FOR DEV ENVIRONMENT ONLY
-// DEV MACHINE OVERRIDES SOCKET SERVER VALUE WITH THIS
-if (isDevEnv && process.env.PEERIO_STAGING_SOCKET_SERVER) {
-    cfg.socketServerUrl = process.env.PEERIO_STAGING_SOCKET_SERVER;
+if (isDevEnv) {
+    // DEV MACHINE OVERRIDES SOCKET SERVER VALUE WITH THIS
+    if (process.env.PEERIO_STAGING_SOCKET_SERVER) {
+        cfg.socketServerUrl = process.env.PEERIO_STAGING_SOCKET_SERVER;
+    }
+    // Allow overridding of whitelabel config.
+    if (process.env.PEERIO_WHITELABEL) {
+        cfg.whiteLabel.name = process.env.PEERIO_WHITELABEL;
+    }
 }
 
 // --- DIAGNOSTIC STARTUP LOG
@@ -77,6 +83,5 @@ try {
 } catch (err) {
     console.log(err);
 }
-
 
 module.exports = cfg;


### PR DESCRIPTION
Adds `npm run start-medcryptor` and updates release builder to enable nightly and staging builds.

#### Relevant info and issue/PR links 
 
https://app.clubhouse.io/peerio/story/7951/desktop-configure-medcryptor-releases-autoupdate


#### Testing instructions  


----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
