### PR TITLE
style: fix unread message buttons positioning

### DIFF
--- a/src/styles/components/list.scss
+++ b/src/styles/components/list.scss
@@ -26,7 +26,7 @@
   @extend %flex-col;
   @extend %flex-shrink-0;
   position: relative;
-  height: 100vh;
+  height: auto;
   width: $width-list;
 
   .list {

--- a/src/ui/chat/components/ChatList.scss
+++ b/src/ui/chat/components/ChatList.scss
@@ -64,7 +64,7 @@
     align-items: center;
     justify-content: center;
 
-    position: fixed;
+    position: absolute;
     z-index: 2;
     height: 36px;
     width: $width-unread-notif;


### PR DESCRIPTION
#### Relevant info and issue/PR links
https://app.clubhouse.io/peerio/story/18894/desktop-unread-message-indicator-shows-on-top-of-banner

#### Testing instructions
The unread message buttons in the message list sidebar are now `absolute` positioned which means they'll stay inside the bounds of the message list. So they should still show up even when the "Peerio is closing" banner is active.

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
